### PR TITLE
Remove UB from Lazy::PostponedReference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,14 +162,16 @@ pub use {
     ops::Lazy as Parser,
 };
 
+use std::{cell::OnceCell, rc::Rc};
+
 use ops::Lazy;
 
 /// Promise a parser that can't be computed yet (usually because it nests itself).
 #[must_use]
 #[inline(always)]
 #[allow(clippy::ref_option_ref)]
-pub const fn postponed<I: Clone + Ord>() -> Lazy<I> {
-    Lazy::Postponed
+pub fn postponed<I: Clone + Ord>() -> Lazy<I> {
+    Lazy::Postponed(ops::Postponed(Rc::new(OnceCell::new())))
 }
 
 /// Accept only the empty string.

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -19,47 +19,62 @@ pub struct Postponed<I: Clone + Ord>(pub(crate) Rc<OnceCell<Lazy<I>>>);
 #[derive(Debug, Clone)]
 pub struct PostponedRef<I: Clone + Ord>(pub(crate) Weak<OnceCell<Lazy<I>>>);
 
-impl<I: Clone + Ord> Hash for Postponed<I> {
+impl<I: Clone + Ord + Hash> Hash for Postponed<I> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        todo!()
+        self.0.get().unwrap().hash(state)
     }
 }
 
 impl<I: Clone + Ord> PartialOrd for Postponed<I> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        todo!()
+        self.0.get().unwrap().partial_cmp(other.0.get().unwrap())
     }
 }
 
 impl<I: Clone + Ord> Ord for Postponed<I> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        todo!()
+        self.0.get().unwrap().cmp(other.0.get().unwrap())
     }
 }
 
 impl<I: Clone + Ord> PartialEq for PostponedRef<I> {
     fn eq(&self, other: &Self) -> bool {
-        todo!()
+        self.0
+            .upgrade()
+            .unwrap()
+            .get()
+            .unwrap()
+            .eq(other.0.upgrade().unwrap().get().unwrap())
     }
 }
 
 impl<I: Clone + Ord> Eq for PostponedRef<I> {}
 
-impl<I: Clone + Ord> Hash for PostponedRef<I> {
+impl<I: Clone + Ord + Hash> Hash for PostponedRef<I> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        todo!()
+        self.0.upgrade().unwrap().get().unwrap().hash(state)
     }
 }
 
 impl<I: Clone + Ord> PartialOrd for PostponedRef<I> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        todo!()
+        self.0
+            .upgrade()
+            .unwrap()
+            .get()
+            .unwrap()
+            .partial_cmp(other.0.upgrade().unwrap().get().unwrap())
     }
 }
 
 impl<I: Clone + Ord> Ord for PostponedRef<I> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        todo!()
+        self.0
+            .upgrade()
+            .unwrap()
+            .get()
+            .unwrap()
+            .cmp(other.0.upgrade().unwrap().get().unwrap())
     }
 }
 


### PR DESCRIPTION
I know that you already reverted the commits, but if you want to try again this would probably be a better starting point. This is pretty much the same as your earlier approach, but without using raw pointers.